### PR TITLE
bug(vocab): removed alphabets without terms

### DIFF
--- a/client/src/components/vocab/vocab.js
+++ b/client/src/components/vocab/vocab.js
@@ -6,6 +6,7 @@ import "./vocab.css";
 class Vocab extends Component {
   render() {
     console.log(Terms);
+    let letters = Terms.terms.filter(x => x.id).map(x => x.id)
     return (
       <div className="content">
         <div className="Container">
@@ -13,15 +14,7 @@ class Vocab extends Component {
           <div className="Terms">
             <div className="tags">
               <h4>
-                <a href="#A">A</a>-<a href="#B">B</a>-<a href="#c">C</a>-
-                <a href="#D">D</a>-<a href="#E">E</a>-<a href="#F">F</a>-
-                <a href="#G">G</a>-<a href="#H">H</a>-<a href="#I">I</a>-
-                <a href="#J">J</a>-<a href="#K">K</a>-<a href="#L">L</a>-
-                <a href="#M">M</a>-<a href="#N">N</a>-<a href="#O">O</a>-
-                <a href="#P">P</a>-<a href="#Q">Q</a>-<a href="#R">R</a>-
-                <a href="#S">S</a>-<a href="#T">T</a>-<a href="#U">U</a>-
-                <a href="#V">V</a>-<a href="#W">W</a>-<a href="#X">X</a>-
-                <a href="#Y">Y</a>-<a href="#Z">Z</a>
+                {letters.map((x,i) => <><a href={`#${x}`}>{x}</a>{i!==letters.length-1 && "-"}</>)}
               </h4>
               -
             </div>


### PR DESCRIPTION
## Learn section has letter tabs without terms (#74)

Earlier, if the user selected alphabets corresponding to terms that were not present, then no visual change happened (the URL got updated though). This hampered the user experience.

Now, such alphabets won't be shown to the users.

### Related issue
Closes: #134

### Changes Made
The alphabets would be filtered out on the basis of whether they have terms corresponding to them or not. Only filtered alphabets would be displayed to the user.

### Type of change
Bug Fix

