### PR TITLE
fix(learn): added tabs and player size fix

### DIFF
--- a/client/src/components/learn/learn.css
+++ b/client/src/components/learn/learn.css
@@ -1,0 +1,20 @@
+.learn-tabs {
+    justify-content: space-evenly;
+    padding: 1rem .5rem 0rem 1rem;
+    border-bottom: 0;
+    margin-bottom: 2rem;
+}
+.learn-tab.nav-link{
+    border-radius: 0;
+    padding: 1rem 4rem;
+}
+.learn-tab.nav-link.active{
+    border:0;
+    color: #007bff;
+    font-weight:600;
+    background-color: transparent;
+    border-bottom: 1px solid #007bff;
+}
+.learn-tab:hover{
+    color: #007bff;
+}

--- a/client/src/components/learn/learn.js
+++ b/client/src/components/learn/learn.js
@@ -1,13 +1,26 @@
-import React, { Component } from "react";
+import React, { useState } from "react";
+import { Tab, Tabs } from "react-bootstrap";
 import Videos from "../videos/videos";
 import Vocab from "../vocab/vocab";
 import "./learn.css";
 
 const Learn = () => {
+  const [currentTab, setCurrentTab] = useState("Vocabulary");
+
   return (
     <div>
-      <Vocab />
-      <Videos />
+      <Tabs
+        activeKey={currentTab}
+        onSelect={(t) => setCurrentTab(t)}
+        className="learn-tabs"
+      >
+        <Tab eventKey="Vocabulary" title="Vocabulary" tabClassName="learn-tab">
+          <Vocab />
+        </Tab>
+        <Tab eventKey="Videos" title="Videos" tabClassName="learn-tab">
+          <Videos />
+        </Tab>
+      </Tabs>
     </div>
   );
 };

--- a/client/src/components/videos/videos.css
+++ b/client/src/components/videos/videos.css
@@ -2,5 +2,4 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 100vh;
 }

--- a/client/src/components/videos/videos.js
+++ b/client/src/components/videos/videos.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import './videos.css';
 const Videos=() => {
+    const availableHt = window.innerHeight;
     return (
         <div className='chessBoard'>
-            <iframe src='https://lichess.org/tv/frame?theme=blue-marble&bg=dark' style={{width: '800px', height: '800px'}} allowtransparency='true' frameborder='0'></iframe>
+            <iframe src='https://lichess.org/tv/frame?theme=blue-marble&bg=dark' style={{width: availableHt - 180, height: availableHt - 150}} allowtransparency='true' frameborder='0'></iframe>
         </div>
     );
 };


### PR DESCRIPTION
## Related Issue
(Video player extends out of visible area #83 )
Earlier, the video player extended the scope of the visible area which made it difficult to see the entire board in one go.

#### Closes: #83 

### Changes made

- Tabs have been added to browse between multiple sections of the Learn page (can be extended to add other sections as well, later on).
- The dimensions of the video player have been made responsive w.r.t the height of users' device i.e. player height is related to screen height after eliminating the header area; player width has also been adjusted to screen height.  
