### PR TITLE
alignment_fixed

### DIFF
--- a/client/src/components/vocab/vocab.css
+++ b/client/src/components/vocab/vocab.css
@@ -25,7 +25,7 @@ html {
   width: 100%;
   height: auto;
   min-height: 100px;
-  background-color: grey;
+  background-color: #1d1e22;
 }
 
 .term-title {
@@ -37,12 +37,11 @@ html {
 
 .meaning {
   width: 70%;
-  padding-top: 4vh;
   background-color: #1d1e22;
   color: white;
   padding-left: 20px;
-  padding-top: auto;
   padding-right: 20px;
+  align-self: center;
 }
 
 .tags {


### PR DESCRIPTION
1). The background color grey is changed to #1d1e22 as you can see in the image in the issue.
2). Both Paddings were removed because they were of no use.
3). align-self: center is used to make the content in center.

Closes ISSUE #99



![Screenshot (334)](https://user-images.githubusercontent.com/56949668/114284202-ed661300-9a6b-11eb-82a2-fcb01077f1b3.png)
